### PR TITLE
add guide to modding tutorials

### DIFF
--- a/docs/source/guides/moddingtutorials.rst
+++ b/docs/source/guides/moddingtutorials.rst
@@ -1,5 +1,7 @@
 Modding Tutorials
 =================
 
+* `NoSkill modding guide <https://noskill.gitbook.io/titanfall2/>`_
+
 .. note::
     This project is under active development.


### PR DESCRIPTION
I saw this NoSkill guide recommended in the cheatsheet page, so I thought it belonged on the modding tutorials page too (especially since it's empty). 