### PR TITLE
Localisation guide

### DIFF
--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -68,8 +68,25 @@ You can import them from your ``mod.json`` manifesto this way:
 Use translations in your code
 -----------------------------
 
-* Use keys in menus
-* ``Localize``
+To translate UI elements like menus, you have to insert strings containing your translation keys, preceded by a ``#``.
+
+For example, to translate the "Launch Northstar" button on main menu, instead of calling:
+
+.. code-block:: javascript
+
+    AddComboButton( comboStruct, headerIndex, buttonIndex++, "Launch Northstar" )
+
+We'll use:
+
+.. code-block:: javascript
+
+    AddComboButton( comboStruct, headerIndex, buttonIndex++, "#MENU_LAUNCH_NORTHSTAR" )
+
+You can also use the ``Localize`` method client-side:
+
+.. code-block:: javascript
+
+    Localize( "#MENU_LAUNCH_NORTHSTAR" )
 
 Northstar translations
 ----------------------

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -17,7 +17,7 @@ Languages natively supported by Titanfall2 are:
 * Portuguese
 * Russian
 * Spanish
-* Traditional Chinese
+* Traditional Chinese (``"tchinese"`` lang code)
 
 Create translation files
 ------------------------
@@ -97,5 +97,5 @@ They're all located in ``"Northstar.Client"`` mod: `Northstar localisation files
 
 .. note ::
     Don't hesitate to submit a PR if you notice a typo!
-    
+
     To test your modifications go to `Origin (My games library) -> Titanfall 2 (right click) -> Game Properties -> Advanced Launch Options` and select the language you modified from the dropdown.

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -28,14 +28,14 @@ Here's what a translation file looks like:
 
     "lang"
     {
-	    "Language" "english"
-	    "Tokens"
+        "Language" "english"
+        "Tokens"
         {
             "MENU_LAUNCH_NORTHSTAR" "Launch Northstar"
             "MENU_TITLE_MODS" "Mods"
             "RELOAD_MODS" "Reload Mods"
             "WARNING" "Warning"
-            "CORE_MOD_DISABLE_WARNING"  "Disabling core mods can break your client!"
+            "CORE_MOD_DISABLE_WARNING" "Disabling core mods can break your client!"
             "DISABLE" "Disable"
         }
     }
@@ -57,8 +57,8 @@ You can import them from your ``mod.json`` manifesto this way:
 
     {
         "Localisation": [
-	        "resource/northstar_client_localisation_%language%.txt"
-	    ]
+            "resource/northstar_client_localisation_%language%.txt"
+        ]
     }
 
 .. note::

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -96,6 +96,5 @@ Northstar adds new strings to the game which can be localised to match the langu
 They're all located in ``"Northstar.Client"`` mod: `Northstar localisation files on GitHub <https://github.com/R2Northstar/NorthstarMods/blob/main/Northstar.Client/mod/resource>`_
 
 .. note ::
-    Don't hesitate to submit a PR if you notice a typo!
-
+    
     To test your modifications go to `Origin (My games library) -> Titanfall 2 (right click) -> Game Properties -> Advanced Launch Options` and select the language you modified from the dropdown.

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -1,9 +1,23 @@
 Localisation
 ============
 
+For your content to reach as many people as possible, it is important to have it translated in users' natural language.
+This guide will help you do that!
 
 Languages list
 --------------
+
+Languages natively supported by Titanfall2 are:
+
+* English
+* French
+* German
+* Italian
+* Japanese
+* Portuguese
+* Russian
+* Spanish
+* Traditional Chinese
 
 Create translation files
 ------------------------

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -1,10 +1,30 @@
 Localisation
 ============
 
+
+Languages list
+--------------
+
+Create translation files
+------------------------
+
+* Create one file per supported language
+* ``UTF-16 LE`` format
+* Integrate them in your ``mod.json`` manifesto
+
+Use translations in your code
+-----------------------------
+
+* Use keys in menus
+* ``Localize``
+
+Northstar translations
+----------------------
+
 Northstar adds new strings to the game which can be localised to match the language you are using on your Titanfall 2 installation.
 
 Files to translate
-------------------
+^^^^^^^^^^^^^^^^^^
 
 There are the two files that need to be translated, use the English version as a base. After you finish make sure that the files are encoded in `UTF-16 LE` before opening a Pull Request.
 

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -44,7 +44,7 @@ It begins with the ``"lang"`` instruction, contains a ``"Language"`` key indicat
 a ``"Token"`` key indexing all translations.
 
 .. warning ::
-    Translations files must use ``"UTF-16 LE"`` encoding.
+    If the translation file contains any non-ASCII character, it must use ``"UTF-16 LE"`` encoding.
 
 You'll have to create one file per supported language, and all your files must be named in a similar fashion.
 

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -17,7 +17,7 @@ Languages natively supported by Titanfall2 are:
 * Portuguese
 * Russian
 * Spanish
-* Traditional Chinese (``"tchinese"`` lang code)
+* Traditional Chinese (``"tchinese"``)
 
 Create translation files
 ------------------------

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -97,4 +97,5 @@ They're all located in ``"Northstar.Client"`` mod: `Northstar localisation files
 
 .. note ::
     
-    To test your modifications go to `Origin (My games library) -> Titanfall 2 (right click) -> Game Properties -> Advanced Launch Options` and select the language you modified from the dropdown.
+    To test your modifications, change your game language: with Origin, go to `Origin (My games library) -> Titanfall 2 (right click) -> Game Properties -> Advanced Launch Options`;
+    with Steam, go to `Titanfall 2 page -> Manage (cog) -> Properties -> Language`.

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -93,12 +93,9 @@ Northstar translations
 
 Northstar adds new strings to the game which can be localised to match the language you are using on your Titanfall 2 installation.
 
-Files to translate
-^^^^^^^^^^^^^^^^^^
+They're all located in ``"Northstar.Client"`` mod: `Northstar localisation files on GitHub <https://github.com/R2Northstar/NorthstarMods/blob/main/Northstar.Client/mod/resource>`_
 
-There are the two files that need to be translated, use the English version as a base. After you finish make sure that the files are encoded in `UTF-16 LE` before opening a Pull Request.
-
-1. `Northstar.Client/mod/resource/northstar_client_localisation_english.txt <https://github.com/R2Northstar/NorthstarMods/blob/main/Northstar.Client/mod/resource/northstar_client_localisation_english.txt>`_
-2. `Northstar.Custom/mod/resource/northstar_custom_english.txt <https://github.com/R2Northstar/NorthstarMods/blob/main/Northstar.Custom/mod/resource/northstar_custom_english.txt>`_
-
-To test your modifications go to `Origin (My games library) -> Titanfall 2 (right click) -> Game Properties -> Advanced Launch Options` and select the language you modified from the dropdown.
+.. note ::
+    Don't hesitate to submit a PR if you notice a typo!
+    
+    To test your modifications go to `Origin (My games library) -> Titanfall 2 (right click) -> Game Properties -> Advanced Launch Options` and select the language you modified from the dropdown.

--- a/docs/source/guides/localisation.rst
+++ b/docs/source/guides/localisation.rst
@@ -22,9 +22,48 @@ Languages natively supported by Titanfall2 are:
 Create translation files
 ------------------------
 
-* Create one file per supported language
-* ``UTF-16 LE`` format
-* Integrate them in your ``mod.json`` manifesto
+Here's what a translation file looks like:
+
+.. code-block:: json
+
+    "lang"
+    {
+	    "Language" "english"
+	    "Tokens"
+        {
+            "MENU_LAUNCH_NORTHSTAR" "Launch Northstar"
+            "MENU_TITLE_MODS" "Mods"
+            "RELOAD_MODS" "Reload Mods"
+            "WARNING" "Warning"
+            "CORE_MOD_DISABLE_WARNING"  "Disabling core mods can break your client!"
+            "DISABLE" "Disable"
+        }
+    }
+
+It begins with the ``"lang"`` instruction, contains a ``"Language"`` key indicating language of current file's translations, and 
+a ``"Token"`` key indexing all translations.
+
+.. warning ::
+    Translations files must use ``"UTF-16 LE"`` encoding.
+
+You'll have to create one file per supported language, and all your files must be named in a similar fashion.
+
+For example, Northstar translation files are named ``"northstar_client_localisation_english.txt"``, ``"northstar_client_localisation_french.txt"``, 
+``"northstar_client_localisation_german.txt"`` etc.
+
+You can import them from your ``mod.json`` manifesto this way:
+
+.. code-block:: json
+
+    {
+        "Localisation": [
+	        "resource/northstar_client_localisation_%language%.txt"
+	    ]
+    }
+
+.. note::
+    The ``"%language%"`` syntax allows VM to load up translations matching game language (e.g. an English client will automatically use 
+    ``"northstar_client_localisation_english.txt"`` file)
 
 Use translations in your code
 -----------------------------


### PR DESCRIPTION
Previously, the localisation guide only featured a section about Northstar localisation files.

It now contains:
* languages list
* how to create a translation file
  * how to import it from `mod.json` manifesto
* how to use translations from code