### PR TITLE
Add guide for contributing to ModdingDocs

### DIFF
--- a/docs/source/guides/contributing.rst
+++ b/docs/source/guides/contributing.rst
@@ -1,0 +1,62 @@
+Contributing to ModdingDocs
+===========================
+
+All contributions to ModdingDocs are welcome. To add a change simply make a pull request to the `ModdingDocs repo <https://github.com/R2Northstar/ModdingDocs/>`_.
+
+ModdingDocs uses `reStructuredText <https://en.wikipedia.org/wiki/ReStructuredText>`_.
+
+A cheatsheet for reStructuredText syntax can be found here: https://docs.generic-mapping-tools.org/6.2/rst-cheatsheet.html
+
+Setting up the build environment for docs
+-----------------------------------------
+
+You don't necessarily need to do this. You could just edit the files in an editor of your choice and then push the changes, wait for a GitHub actions to create a build and then check it out online. However, building the documentation locally allows you to quickly see whether the changes you made were correct or if there were any issues.
+
+To set up a build locally, do the following:
+
+Clone the `ModdingDocs repo <https://github.com/R2Northstar/ModdingDocs/>`_, e.g.
+
+
+.. code:: bash
+
+    git clone https://github.com/R2Northstar/ModdingDocs/
+
+
+Opened the clone repo.
+
+Setup a `Python virtual environment <https://docs.python.org/3/tutorial/venv.html>`_
+(this is not strictly necessary but can help keep your Python install clean)
+
+.. code:: bash
+
+    # Create virtual environment
+    python3 -m venv venv
+
+    # Activate it
+    source venv/bin/activate
+
+Install the Python packages necessary to build the docs
+
+.. code:: bash
+
+    pip install sphinx furo
+
+Finally to actually build the docs, go to the ``docs/`` directory and run `make html`, i.e.
+
+.. code:: bash
+
+    cd docs/
+    make html
+
+This will create a new folder inside ``docs/`` called ``build/`` where under ``html/`` you can find the rendered HTML files which you can open in the browser of your choice.
+
+
+Tips and tricks
+---------------
+
+If you're using `Visual Studio Code <https://code.visualstudio.com/>`_, the following extensions might be of interest:
+
+
+- `snekvik.simple-rst <https://marketplace.visualstudio.com/items?itemName=trond-snekvik.simple-rst>`_: for syntax highlighting
+- `lextudio.restructuredtext <https://marketplace.visualstudio.com/items?itemName=lextudio.restructuredtext>`_: for previewing the rst files in VS Code
+- `ms-vscode.live-server <https://marketplace.visualstudio.com/items?itemName=ms-vscode.live-server>`_: for previewing HTML files in VS Code

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -29,7 +29,6 @@ If you know anything about any function, object or concept please dont hesitate 
    :hidden:
    :caption: Guides
 
-   /guides/contributing
    /guides/gettingstarted
    /guides/tools
    /guides/cheatsheet
@@ -42,6 +41,7 @@ If you know anything about any function, object or concept please dont hesitate 
    /guides/soundmodding
    /guides/VTFModding
    /guides/publishing
+   /guides/contributing
 
 .. toctree::
    :maxdepth: 3

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,6 +7,8 @@ Welcome to the Northstar Modding Documentation!
 
    This project is under active development. Please PR everything you can!
 
+   Check :doc:`/guides/contributing` section for getting started with `readthedocs <https://readthedocs.org/>`_ and `reStructuredText <https://en.wikipedia.org/wiki/ReStructuredText>`_.
+
 Contents
 --------
 
@@ -27,6 +29,7 @@ If you know anything about any function, object or concept please dont hesitate 
    :hidden:
    :caption: Guides
 
+   /guides/contributing
    /guides/gettingstarted
    /guides/tools
    /guides/cheatsheet


### PR DESCRIPTION
Basic build instructions and useful tools for anyone unfamiliar with working with reStructuredText and readthedocs.

It's not fully in the state I want the page to be in. For example it's written for someone familiar with working with CLI and having some of the necessary dependencies installed (`python` and `make`) but it's in a state where I'd consider it publishable with improvements following later.

Definitely better than what we have currently (i.e. nothing :P)