### PR TITLE
Use `requirements.txt` to install Python dependency

### DIFF
--- a/docs/source/guides/contributing.rst
+++ b/docs/source/guides/contributing.rst
@@ -39,7 +39,7 @@ Install the Python packages necessary to build the docs
 
 .. code:: bash
 
-    pip install sphinx furo
+    pip install -r docs/requirements.txt
 
 Finally to actually build the docs, go to the ``docs/`` directory and run `make html`, i.e.
 


### PR DESCRIPTION
As per https://github.com/R2Northstar/ModdingDocs/pull/44#issuecomment-1183458584