### PR TITLE
Specifiy that second `venv` is folder name

### DIFF
--- a/docs/source/guides/contributing.rst
+++ b/docs/source/guides/contributing.rst
@@ -29,7 +29,7 @@ Setup a `Python virtual environment <https://docs.python.org/3/tutorial/venv.htm
 
 .. code:: bash
 
-    # Create virtual environment
+    # Create virtual environment (the second `venv` is the name of the folder of the virtual environment)
     python3 -m venv venv
 
     # Activate it


### PR DESCRIPTION
Just to make it a bit more clear what the command does for anyone new to Python virtual environments.

Change made based on user feedback.