### PR TITLE
Add sphinx-tabs and update contributing.rst to match

### DIFF
--- a/docs/source/_static/styles/main.css
+++ b/docs/source/_static/styles/main.css
@@ -28,6 +28,13 @@
 	background-color: rgba(66, 71, 127,0.1);
 }
 
+.sphinx-tabs-tab {
+	padding-top: 0.5rem !important;
+	padding-right: 1rem !important;
+	padding-bottom: 0rem !important;
+	padding-left: 1rem !important;
+}
+
 
 /* disabled due to breaking when the lexer fails and no syntax highlighting happens. */
 /* body:not([data-theme="light"]) .highlight {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ author = "Northstar Developer Team"
 release = "0.1"
 version = "0.1.0"
 
+
 # -- General configuration
 
 extensions = [
@@ -17,6 +18,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx_tabs.tabs",
 ]
 
 intersphinx_mapping = {

--- a/docs/source/guides/contributing.rst
+++ b/docs/source/guides/contributing.rst
@@ -28,13 +28,25 @@ First, you need to have a relatively recent version of Python installed - 3.8 or
 tl:dr;
 ^^^^^^
 
-.. code:: bash
+.. tabs::
 
-    git clone https://github.com/R2Northstar/ModdingDocs/
-    cd ModdingDocs
-    py -m pip install poetry
-    py -m poetry install
-    py -m poetry run build
+    .. code-tab:: powershell Windows
+
+        git clone https://github.com/R2Northstar/ModdingDocs/
+        cd ModdingDocs
+        py -m pip install poetry
+        py -m poetry install
+        py -m poetry run build
+    
+    .. code-tab:: bash Linux
+
+        git clone https://github.com/R2Northstar/ModdingDocs/
+        cd ModdingDocs
+        python3 -m pip install poetry
+        python3 -m poetry install
+        python3 -m poetry run build
+
+
 
 Explanation
 ^^^^^^^^^^^
@@ -49,32 +61,49 @@ Open a terminal wherever you want the files to end up and clone the `ModdingDocs
 
 Your terminal should now be open in the ModdingDocs folder.
 
-Next, on Windows do:
+Next, you need to install `Poetry <https://python-poetry.org/docs/cli/>`_, the dependency management and build tool used:
 
-.. code:: bash
+.. tabs::
 
-    # Install Poetry, the build tool used by ModdingDocs
-    py -m pip install poetry
+    .. code-tab:: powershell Windows
+        
+        py -m pip install poetry
+        
+    .. code-tab:: bash Linux
 
-For other OSs replace ``py`` with ``python3`` or whichever python executable you prefer.
+        python3 -m pip install poetry
 
-Now, tell poetry to install this project.
+Now, tell poetry to install this project and its dependencies.
 
-.. code:: bash
+.. tabs::
 
-    py -m poetry install
+    .. code-tab:: powershell Windows
+        
+        py -m poetry install
+        
+    .. code-tab:: bash Linux
+
+        python3 -m poetry install
+
 
 After this is done downloading and setting up all the dependencies, you can build it with:
 
-.. code:: bash
 
-    py -m poetry run build
+.. tabs::
+
+    .. code-tab:: powershell Windows
+        
+        py -m poetry run build
+        
+    .. code-tab:: bash Linux
+
+        python3 -m poetry run build
+
 
 This should rebuild the docs on changes and open them in your default browser with live reloading.
 
-Note: if you added python to the PATH you can omit the ``py -m`` or alternatives.
 
-Tips and tricks
+VSCode
 ---------------
 
 If you're using `Visual Studio Code <https://code.visualstudio.com/>`_, the following extensions might be of interest:
@@ -82,3 +111,15 @@ If you're using `Visual Studio Code <https://code.visualstudio.com/>`_, the foll
 
 - `snekvik.simple-rst <https://marketplace.visualstudio.com/items?itemName=trond-snekvik.simple-rst>`_: for syntax highlighting
 - `lextudio.restructuredtext <https://marketplace.visualstudio.com/items?itemName=lextudio.restructuredtext>`_: for autocompletion and syntax checks.
+
+.. note::
+    To get the ReStructuredText support working, you will likely need to tell VSCode to use the Poetry environment.
+
+    To do so, open one of the .py files, which should make the python version appear in the bottom right of VSCode.
+
+    Click on it, and select the version with ``(moddingdocs`` after it.
+
+    Then, when looking at a ReStructuredText file there should be ``esbonio:`` in the bottom right.
+
+    Click that to restart the ReStructuredText support. This allows it to see all the dependencies Poetry installed.
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -61,11 +61,11 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "docutils"
-version = "0.19"
+version = "0.18.1"
 description = "Docutils -- Python Documentation Utilities"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "furo"
@@ -293,6 +293,23 @@ sphinx = ">=4.0,<6.0"
 docs = ["furo", "myst-parser", "sphinx-copybutton", "sphinx-inline-tabs", "ipython"]
 
 [[package]]
+name = "sphinx-tabs"
+version = "3.4.1"
+description = "Tabbed views for Sphinx"
+category = "main"
+optional = false
+python-versions = "~=3.7"
+
+[package.dependencies]
+docutils = ">=0.18.0,<0.19.0"
+pygments = "*"
+sphinx = "*"
+
+[package.extras]
+code_style = ["pre-commit (==2.13.0)"]
+testing = ["coverage", "pytest (>=7.1,<8)", "pytest-cov", "pytest-regressions", "pygments", "sphinx-testing", "bs4", "rinohtype"]
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "1.0.2"
 description = "sphinxcontrib-applehelp is a sphinx extension which outputs Apple help books"
@@ -399,7 +416,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "d4168d24a3fe46dc286c8f69143c81ed2abe577a4d30f93ddef1a8519a5ec9a1"
+content-hash = "1d015545c2bdcbaaa1d8360e0a9e3a85d6012c99af7395449844a0d8b100a806"
 
 [metadata.files]
 alabaster = []
@@ -445,6 +462,7 @@ soupsieve = []
 sphinx = []
 sphinx-autobuild = []
 sphinx-basic-ng = []
+sphinx-tabs = []
 sphinxcontrib-applehelp = []
 sphinxcontrib-devhelp = []
 sphinxcontrib-htmlhelp = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.8"
 Sphinx = "^5.0.2"
 furo = "^2022.6.21"
 sphinx-autobuild = "^2021.3.14"
+sphinx-tabs = "^3.4.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
The sphinx-tabs extension allows tabbed views of multiple alternatives, which is nice to show OS dependent docs.

![image](https://user-images.githubusercontent.com/24855949/192146790-175d7cc8-4869-47bf-8d85-dfc3a0d812bd.png)

closes: #81 

unblocks: #85  #84 