### PR TITLE
Document waiting for multiple signals, signal response tables and improve thread explanations

### DIFF
--- a/docs/source/native/async.rst
+++ b/docs/source/native/async.rst
@@ -135,17 +135,17 @@ Signals
 
     :doc:`../reference/respawn/entities`
 
-	.. cpp:function:: void Signal( string signal, table<var, var> results = null )
+    .. cpp:function:: void Signal( string signal, table<var, var> results = null )
 
-		Trigger a signal on this entity. The passed ``results`` will be returned by ``WaitSignal``.
+	Trigger a signal on this entity. The passed ``results`` will be returned by ``WaitSignal``.
 
-	.. cpp:function:: void EndSignal( string signal )
+    .. cpp:function:: void EndSignal( string signal )
 
-		Ends this thread when the identifier is signaled on this entity
+	Ends this thread when the identifier is signaled on this entity
 
-	.. cpp:function:: table<var, var> WaitSignal( string signal )
+    .. cpp:function:: table<var, var> WaitSignal( string signal )
 
-		Halts this thread until a signal is activated for this entity
+	Halts this thread until a signal is activated for this entity
 
     .. cpp:function:: void ConnectOutput( string signal, void functionref( entity trigger, entity activator, entity caller, var value ) callback )
 
@@ -155,17 +155,17 @@ Signals
 
         Disconnects the callback from the signal.
 
-	.. cpp:function:: void AddOutput( string outputName, string | entity target, string inputName, string parameter = "", float delay = 0, float maxFires = 0 )
+    .. cpp:function:: void AddOutput( string outputName, string | entity target, string inputName, string parameter = "", float delay = 0, float maxFires = 0 )
 
-		Connects an output on this entity to an input on another entity via code.  The ``target`` can be a name or a named entity.
+	Connects an output on this entity to an input on another entity via code.  The ``target`` can be a name or a named entity.
         
-	.. cpp:function:: void Fire( string signal, string param = "", float delay = 0, entity activator = null, entity caller = null )
+    .. cpp:function:: void Fire( string signal, string param = "", float delay = 0, entity activator = null, entity caller = null )
 
-		Fire a signal on this entity, with optional parm and delay
+	Fire a signal on this entity, with optional parm and delay
 
-	.. cpp:function:: void FireNow( string output, string param = "", float delay = 0, entity activator = null, entity caller = null )
+    .. cpp:function:: void FireNow( string output, string param = "", float delay = 0, entity activator = null, entity caller = null )
 
-		Fire a signal on this entity, with optional parm and delay (synchronous)
+	Fire a signal on this entity, with optional parm and delay (synchronous)
 
 It's also possible to trigger and catch signals with methods that aren't properties of an entity.
 

--- a/docs/source/native/async.rst
+++ b/docs/source/native/async.rst
@@ -97,10 +97,50 @@ You have now created and threaded both functions.
 Signals and flags
 ----------------------
 
+Signals and flags allow threads to wait for events before running some code.
+
 Signals
 ^^^^^^^^^^
 
-Signals and flags allow threads to wait for events before running some code.
+.. cpp:function:: void RegisterSignal( string signal )
+
+    Registers a Signals to use on any entity. It's required to register signals before using them.
+
+.. cpp:class:: CBaseEntity
+
+    :doc:`../reference/respawn/entities`
+
+	.. cpp:function:: void Signal( string signal )
+
+		Trigger a signal on this entity
+
+	.. cpp:function:: void EndSignal( string signal )
+
+		Ends this thread when the identifier is signaled on this entity
+
+	.. cpp:function:: void WaitSignal( string signal )
+
+		Halts this thread until a signal is activated for this entity
+
+    .. cpp:function:: void ConnectOutput( string signal, void functionref( entity trigger, entity activator, entity caller, var value ) callback )
+
+        Register a callback that executes when the ``signal`` has been fired on this Entity
+
+    .. cpp:function:: void DisconnectOutput( string event, void functionref( entity trigger, entity activator, entity caller, var value ) callback )
+
+        Disconnects the callback from the signal.
+
+	.. cpp:function:: void AddOutput( string outputName, string | entity target, string inputName, string parameter = "", float delay = 0, float maxFires = 0 )
+
+		Connects an output on this entity to an input on another entity via code.  The ``target`` can be a name or a named entity.
+        
+	.. cpp:function:: void Fire( string signal, string param = "", float delay = 0, entity activator = null, entity caller = null )
+
+		Fire a signal on this entity, with optional parm and delay
+
+	.. cpp:function:: void FireNow( string output, string param = "", float delay = 0, entity activator = null, entity caller = null )
+
+		Fire a signal on this entity, with optional parm and delay (synchronous)
 
 For example, if we want to tell a player not to give up after being killed several times, we can write it this way:
 
@@ -149,36 +189,6 @@ run until player died 42 times.
 
 When you want your thread to die on a given event, you can use ``entity.EndSignal( "OnMultipleDeaths" )``; when said signal 
 is set, thread will end (after calling any `OnThreadEnd` methods).
-
-
-.. cpp:function:: void RegisterSignal( string signal )
-
-    Registers a Signals to use on any entity
-
-.. cpp:class:: CBaseEntity
-
-    :doc:`../reference/respawn/entities`
-
-    .. cpp:function:: void ConnectOutput( string signal, void functionref( entity trigger, entity activator, entity caller, var value ) callback )
-
-        Register a callback that executes when the ``signal`` has been fired on this Entity
-
-    .. cpp:function:: void DisconnectOutput( string event, void functionref( entity trigger, entity activator, entity caller, var value ) callback )
-
-        Disconnects the callback from the signal.
-
-	.. cpp:function:: void AddOutput( string outputName, string | entity target, string inputName, string parameter = "", float delay = 0, float maxFires = 0 )
-
-		Connects an output on this entity to an input on another entity via code.  The ``target`` can be a name or a named entity.
-        
-	.. cpp:function:: void Fire( string signal, string param = "", float delay = 0, entity activator = null, entity caller = null )
-
-		Fire a signal on this entity, with optional parm and delay
-
-	.. cpp:function:: void FireNow( string output, string param = "", float delay = 0, entity activator = null, entity caller = null )
-
-		Fire a signal on this entity, with optional parm and delay (synchronous)
-
 
 Flags
 ^^^^^^^^^^

--- a/docs/source/native/async.rst
+++ b/docs/source/native/async.rst
@@ -10,7 +10,7 @@ In threaded functions, it's possible to halt a threaded function with ``wait`` s
 
 You can use the ``IsNewThread()`` function to determine if the current function is threaded off.
 
-For more information, check out the `squirrel documentation on threads <http://www.squirrel-lang.org/squirreldoc/reference/language/threads.html>` and `sq functions of threads <http://www.squirrel-lang.org/squirreldoc/reference/language/builtin_functions.html#thread>`. rsquirrel is very similar to vanilla squirrel in this regard.
+For more information, check out the `squirrel documentation on threads <http://www.squirrel-lang.org/squirreldoc/reference/language/threads.html>`_ and `sq functions of threads <http://www.squirrel-lang.org/squirreldoc/reference/language/builtin_functions.html#thread>`_. rsquirrel is very similar to vanilla squirrel in this regard.
 
 Spinning off a thread
 ^^^^
@@ -56,7 +56,7 @@ To wait a single frame, don't use ``wait 0`` since it doesn't actually wait a ga
 When using infinite loops it's important to work with ``wait`` statements to avoid the game freezing.
 
 Example Script
---------------
+^^^^
 
 .. code-block:: javascript
 

--- a/docs/source/native/async.rst
+++ b/docs/source/native/async.rst
@@ -169,7 +169,7 @@ Signals
 
 It's also possible to trigger and catch signals with methods that aren't properties of an entity.
 
-.. cpp:function:: void Signal( entity ent, string signal, table<var, var> results = null )
+.. cpp:function:: void Signal( var obj, string signal, table<var, var> results = null )
 
     Trigger a signal on ``ent``. The passed ``results`` will be returned by ``WaitSignal``.
 
@@ -182,7 +182,7 @@ It's also possible to trigger and catch signals with methods that aren't propert
         // Wait for the NPC to die, delete, or get leeched, then remove the npc from the array
 	    WaitSignal( ent, "OnDeath", "OnDestroy", "OnLeeched" )
 
-.. cpp:function:: void EndSignal( entity ent, string signal )
+.. cpp:function:: void EndSignal( var obj, string signal )
 
     Ends this thread when the identifier is signaled on ``ent``
 

--- a/docs/source/native/async.rst
+++ b/docs/source/native/async.rst
@@ -110,15 +110,15 @@ Signals
 
     :doc:`../reference/respawn/entities`
 
-	.. cpp:function:: void Signal( string signal )
+	.. cpp:function:: void Signal( string signal, table<var, var> results = null )
 
-		Trigger a signal on this entity
+		Trigger a signal on this entity. The passed ``results`` will be returned by ``WaitSignal``.
 
 	.. cpp:function:: void EndSignal( string signal )
 
 		Ends this thread when the identifier is signaled on this entity
 
-	.. cpp:function:: void WaitSignal( string signal )
+	.. cpp:function:: table<var, var> WaitSignal( string signal )
 
 		Halts this thread until a signal is activated for this entity
 
@@ -141,6 +141,21 @@ Signals
 	.. cpp:function:: void FireNow( string output, string param = "", float delay = 0, entity activator = null, entity caller = null )
 
 		Fire a signal on this entity, with optional parm and delay (synchronous)
+
+It's also possible to trigger and catch signals with methods that aren't properties of an entity.
+
+.. cpp:function:: void Signal( entity ent, string signal, table<var, var> results = null )
+
+    Trigger a signal on ``ent``. The passed ``results`` will be returned by ``WaitSignal``.
+
+.. cpp:function:: table<var, var> WaitSignal( entity ent, ... )
+
+    Wait for any of the passed signals to be triggered.
+
+    .. code-block:: javascript
+
+        // Wait for the NPC to die, delete, or get leeched, then remove the npc from the array
+	    WaitSignal( ent, "OnDeath", "OnDestroy", "OnLeeched" )
 
 For example, if we want to tell a player not to give up after being killed several times, we can write it this way:
 


### PR DESCRIPTION
It's possible to wait for one of many signals
```js
// Wait for the NPC to die, delete, or get leeched, then remove the npc from the array
WaitSignal( ent, "OnDeath", "OnDestroy", "OnLeeched" )
```

Get a signal response
```js
svGlobal.levelEnt.Signal( "PlayerDidSpawn", { player=player } )
// ...
entity player = expect entity( svGlobal.levelEnt.WaitSignal( "PlayerDidSpawn" ).player )
```