### PR TITLE
Document NSGetLocalPlayerUID()

### DIFF
--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -12,6 +12,7 @@ Northstar API
     /reference/northstar/serversiderui.rst
     /reference/northstar/httprequests.rst
     /reference/northstar/jsonparsing.rst
+    /reference/northstar/usefulfuncs.rst
 
 Respawn API
 -----------

--- a/docs/source/reference/northstar/usefulfuncs.rst
+++ b/docs/source/reference/northstar/usefulfuncs.rst
@@ -1,0 +1,20 @@
+Useful Functions
+================
+
+Below are a list of useful functions added by Northstar.
+
+Functions
+---------
+
+.. _useful_funcs_nsgetlocalplayeruid:
+
+.. cpp:function:: string NSGetLocalPlayerUID()
+
+	Returns the local player's UID, if any.
+    Available on CLIENT, UI and SERVER scripts.
+	
+	**Returns:** 
+	
+	- The local player's string UID if any, or null otherwise.
+
+


### PR DESCRIPTION
This PR documents the new `string NSGetLocalPlayerUID()` function, added by Launcher PR [#371](https://github.com/R2Northstar/NorthstarLauncher/pull/371).