### PR TITLE
Fix weapon KV table path to use absolute path

### DIFF
--- a/docs/source/guides/keyvalue/weaponkeyvalues.rst
+++ b/docs/source/guides/keyvalue/weaponkeyvalues.rst
@@ -13,7 +13,7 @@ List of KeyValues
 ------------------------
 
 .. csv-table:: Weapon Key Value List
-  :file: ../../../_static/keyvaluetable.csv
+  :file: /_static/keyvaluetable.csv
   :delim: |
   :widths: 15, 20, 5, 30, 30
   :header-rows: 1


### PR DESCRIPTION
Used to be relative which got messed up with doc restructuring, so changed it to an absolute path which is much better.