### PR TITLE
Improve the Squirrel API docs

### DIFF
--- a/docs/source/squirrel/cpp_api/objecthandling.rst
+++ b/docs/source/squirrel/cpp_api/objecthandling.rst
@@ -155,6 +155,15 @@ Getting Objects from the stack
 
 .. cpp:function:: SQTable* getConstants(HSquirrelVM* sqvm)
 
+    .. note::
+
+        This function (``server.dll+0x5920```) is not available in the launcher or plugins at the moment.
+
+        You can open a PR if you need it now.
+
+        To define an integer constant you can use :ref:`defconst <defconst>` instead.
+
+
     :param HSquirrelVM* sqvm: the target vm
     :returns: the table of constants
 
@@ -249,6 +258,8 @@ Getting Objects from the stack
     :param SQInteger stackpos: stack position of the object
     :returns: an ``SQRESULT`` that indicates whether or not the access was successful.
 
+    pops a key from the stack and performs a get operation on the object at the position idx in the stack; and pushes the result in the stack.
+
 Stack Infos
 -----------
 
@@ -271,3 +282,16 @@ Stack Infos
     .. note::
 
         Not available in `plugins <https://github.com/R2Northstar/NorthstarLauncher/blob/main/NorthstarDLL/plugins/plugin_abi.h>`_
+
+Other
+-----
+
+.. _defconst:
+
+.. cpp:function:: void defconst(CSquirrelVM* csqvm, const SQChar* pName, int nValue)
+
+    :param CSquirrelVM* csqvm: the target vm
+    :param SQChar* pName: the constant name
+    :param int nValue: the constant value
+
+    defines a global squirrel integer constant

--- a/docs/source/squirrel/cpp_api/objecthandling.rst
+++ b/docs/source/squirrel/cpp_api/objecthandling.rst
@@ -172,7 +172,7 @@ Getting Objects from the stack
 
         removeFromStack(sqvm); // don't forget this!
 
-.. _sq_getfunction:
+.. _sq-getfunction:
 
 .. cpp:function:: int sq_getfunction(HSquirrelVM* sqvm, const SQChar* name, SQObject* returnObj, const SQChar* signature)
 
@@ -200,7 +200,7 @@ Getting Objects from the stack
     :param HSquirrelVM* sqvm: The target vm
     :param SQInteger iStackPos: Stack position of the entity
 
-.. _sq_getentityfrominstance:
+.. _sq-getentityfrominstance:
 
 .. cpp:function:: void* __sq_getentityfrominstance(CSquirrelVM* sqvm, SQObject* pInstance, char** ppEntityConstant)
 
@@ -214,7 +214,7 @@ Getting Objects from the stack
 
     There are entity constants for other types, but seemingly CBaseEntity's is the only one needed
 
-.. _sq_getobject:
+.. _sq-getobject:
 
 .. cpp:function:: SQRESULT __sq_getobject(HSquirrelVM* sqvm, SQInteger iStackPos, SQObject* obj)
 
@@ -252,7 +252,7 @@ Getting Objects from the stack
 Stack Infos
 -----------
 
-.. _sq_stackinfos:
+.. _sq-stackinfos:
 
 .. cpp:function:: SQRESULT sq_stackinfos(HSquirrelVM* sqvm, int level, SQStackInfos& out)
 

--- a/docs/source/squirrel/cpp_api/objecthandling.rst
+++ b/docs/source/squirrel/cpp_api/objecthandling.rst
@@ -216,11 +216,30 @@ Getting Objects from the stack
 
 .. _sq_getobject:
 
-.. cpp:function:: __sq_getobject(HSquirrelVM* sqvm, SQInteger iStackPos, SQObject* obj)
+.. cpp:function:: SQRESULT __sq_getobject(HSquirrelVM* sqvm, SQInteger iStackPos, SQObject* obj)
 
     :param HSquirrelVM* sqvm: The target vm
     :param SQInteger iStackPos: Stack position of the object
     :param SQObject* obj: Pointer that will hold the object
+
+    ``obj`` will be overwritten to hold the squirrel object.
+
+    This example adds a native function with the :ref:`ADD_SQFUNC <sq-api-register-native-functions-c-macro>` macro.
+    The function takes a function reference as a callback and calls it immediately.
+    More information about function calls are available :ref:`here <sq-api-calling-functions>`
+
+    .. code-block:: cpp
+
+        ADD_SQFUNC("void", SQCallbackTest, "void functionref()", "", ScriptContext::UI)
+        {
+            SQObject fn; // Make an empty sqobject. This will hold the function object later
+            g_pSquirrel<context>->__sq_getobject(sqvm, 1, &fn); // Assign the function object to the SQOBJECT
+            g_pSquirrel<context>->pushobject(sqvm, &fn); // Push the function object for the call
+            g_pSquirrel<context>->pushroottable(sqvm); // Push the root table for the function stack
+            g_pSquirrel<context>->__sq_call(sqvm, 1, false, true); // call the function with one parameter (the 'this' object)
+
+            return SQRESULT_NULL;
+        }
 
 .. _get:
 

--- a/docs/source/squirrel/cpp_api/sq_functions.rst
+++ b/docs/source/squirrel/cpp_api/sq_functions.rst
@@ -110,6 +110,11 @@ Calling
 .. cpp:function:: SQRESULT Call(const char* funcname)
 
     :param char* funcname: Name of the function to call
+
+    .. note::
+
+        This is a squirrel API wrapper added by northstar. It's not available for plugins and is supposed to abstract squirrel calls.
+
     
     This function assumes the squirrel VM is stopped/blocked at the moment of call
 
@@ -128,6 +133,10 @@ Calling
     :param char* funcname: Name of the function to call
     :param Args... args: vector of args to pass to the function
 
+    .. note::
+
+        This is a squirrel API wrapper added by northstar. It's not available for plugins and is supposed to abstract squirrel calls.
+
     .. code-block:: cpp
 
         Call("PluginCallbackTest", "param"); // PluginCallbackTest("param")
@@ -137,6 +146,10 @@ Calling
 .. cpp:function:: SquirrelMessage AsyncCall(std::string funcname)
 
     :param char* funcname: Name of the function to call
+
+    .. note::
+
+        This is a squirrel API wrapper added by northstar. It's not available for plugins and is supposed to abstract squirrel calls.
 
     This function schedules a call to be executed on the next frame
 
@@ -149,7 +162,12 @@ Calling
     :param char* funcname: Name of the function to call
     :param Args... args: vector of args to pass to the function
 
-.. __call:
+    .. note::
+
+        This is a squirrel API wrapper added by northstar. It's not available for plugins and is supposed to abstract squirrel calls.
+
+
+.. _ns-call:
 
 .. cpp:function:: SQRESULT _call(HSquirrelVM* sqvm, const SQInteger args)
 
@@ -158,12 +176,16 @@ Calling
 
     ``_call`` adds one to the ``args`` count for ``this``.
 
+    .. note::
+
+        This is a squirrel API wrapper added by northstar. It's not available for plugins and is supposed to abstract squirrel calls.
+
     .. code-block:: cpp
 
         SQObject functionobj {};
-        int result = g_pSquirrel<context>->sq_getfunction(sqvm, "PluginCallbackTest", &functionobj, 0);
+        SQRESULT result = g_pSquirrel<context>->sq_getfunction(sqvm, "PluginCallbackTest", &functionobj, 0); // Get a global squirrel function called "PluginCallbackTest"
 
-        if (result != 0)
+        if (result == SQRESULT_ERROR)
         {
             spdlog::error("Unable to find function. Is it global?");
             return SQRESULT_ERROR;
@@ -173,6 +195,19 @@ Calling
         g_pSquirrel<context>->pushroottable(sqvm);
         g_pSquirrel<context>->pushstring(sqvm, "param");
         return g_pSquirrel<context>->_call(sqvm, 1); // PluginCallbackTest("param")
+
+.. _sq-call:
+
+.. cpp:function:: SQRESULT __sq_call(HSquirrelVM* sqvm, SQInteger iArgs, SQBool bShouldReturn, SQBool bThrowError)
+
+    :param HSquirrelVM* sqvm: the target vm
+    :param SQInteger iArgs: number of parameters of the function
+    :param SQBool bShouldReturn: if true the function will push the return value to the stack
+    :param SQBool bThrowError: if true, if a runtime error occurs during the execution of the call, the vm will invoke the error handler
+
+    calls a closure or a native closure. The function pops all the parameters and leave the closure in the stack; if retval is true the return value of the closure is pushed. If the execution of the function is suspended through sq_suspendvm(), the closure and the arguments will not be automatically popped from the stack.
+
+    When using to create an instance, push a dummy parameter to be filled with the newly-created instance for the constructor's ``this`` parameter.
 
 Errors
 ------

--- a/docs/source/squirrel/cpp_api/sq_functions.rst
+++ b/docs/source/squirrel/cpp_api/sq_functions.rst
@@ -121,7 +121,7 @@ Calling
 
         Call("PluginCallbackTest"); // PluginCallbackTest()
 
-.. _Call_args:
+.. _Call-args:
 
 .. cpp:function:: SQRESULT Call(const char* funcname, Args... args)
 
@@ -142,7 +142,7 @@ Calling
 
     This is useful for things like threads and plugins, which do not run on the main thread.
 
-.. _AsyncCall_args:
+.. _AsyncCall-args:
 
 .. cpp:function:: SquirrelMessage AsyncCall(std::string funcname, Args... args)
 

--- a/docs/source/squirrel/cpp_api/sq_functions.rst
+++ b/docs/source/squirrel/cpp_api/sq_functions.rst
@@ -1,6 +1,8 @@
 Squirrel Functions
 ==================
 
+.. _sq-api-register-native-functions-c-macro:
+
 Adding Squirrel Functions
 -------------------------
 
@@ -32,12 +34,14 @@ Return a string from a native registered function:
         return SQRESULT_NOTNULL; // Signal that the topmost item on the stack is returned by this function
     }
 
+Return a complex ``ornull`` type:
+
 .. code-block:: cpp
 
-    ADD_SQFUNC("array ornull", CPlugComplex, "int n", "returns null", ScriptContext::CLIENT | ScriptContext::SERVER | ScriptContext::UI)
+    ADD_SQFUNC("array<int> ornull", CPlugComplex, "int n", "returns null", ScriptContext::CLIENT | ScriptContext::SERVER | ScriptContext::UI)
     {
         SQInteger n = g_pSquirrel<context>->getinteger(sqvm, 1);
-
+        
         if (n == 0)
             return SQRESULT_NULL;
 
@@ -47,27 +51,7 @@ Return a string from a native registered function:
         g_pSquirrel<context>->pushinteger(sqvm, n * 2);
         g_pSquirrel<context>->arrayappend(sqvm, 2);
 
-        return SQRESULT_NOTNULL; // return the array [ n, n * 2 ]
-    }
-
-Return a complex ``ornull`` type:
-
-.. code-block:: cpp
-
-    ADD_SQFUNC("int ornull", CPlugComplex, "int n", "returns null", ScriptContext::CLIENT | ScriptContext::SERVER | ScriptContext::UI)
-    {
-        SQInteger n = g_pSquirrel<context>->getinteger(sqvm, 1);
-        
-        if (n == 0)
-            return SQRESULT_NULL;
-
-        g_pSquirrel<context>->newarray(sqvm);
-        g_pSquirrel<context>->pushinteger(sqvm, n);
-        g_pSquirrel<context>->arrayappend(sqvm, 2);
-        g_pSquirrel<context>->pushinteger(sqvm, n * 2);
-        g_pSquirrel<context>->arrayappend(sqvm, 2);
-
-        return SQRESULT_NOTNULL; // return the array [ n, n * 2 ]
+        return SQRESULT_NOTNULL; // return the array [ n, n * 2 ] or NULL if n == 0
     }
 
 Replacing Squirrel Functions
@@ -115,6 +99,8 @@ Squirrel functions need to return a ``SQRESULT``. Valid results are
 - ``SQRESULT_NULL`` - This function returns ``null``. Nothing is left over on the stack.
 - ``SQRESULT_NOTNULL`` - This functions returns the last item on the stack.
 - ``SQRESULT_ERROR`` - This function has thrown an error.
+
+.. _sq-api-calling-functions:
 
 Calling
 -------

--- a/docs/source/squirrel/cpp_api/stack.rst
+++ b/docs/source/squirrel/cpp_api/stack.rst
@@ -9,7 +9,7 @@ also when Squirrel calls a native function the parameters will be in the stack a
 Stack Indexes
 -------------
 
-Many API functions can arbitrarily refer to any element in the stack through an index. The stack indexes follow those conventions:
+Many API functions can arbitrarily refer to any element in the stack through an index. The stack indexes follow these conventions:
 
 - 1 is the stack base
 - Negative indexes are considered an offset from top of the stack. For instance -1 is always the last item pushed to the stack

--- a/docs/source/squirrel/cpp_api/stack.rst
+++ b/docs/source/squirrel/cpp_api/stack.rst
@@ -30,12 +30,16 @@ Stack manipulation
 
 The Squirrel API offers several functions to push and retrieve data from the Stack.
 
-Currently there are no more functions implemented in ``squirrel.h``.
-
 .. _removefromstack:
 
 .. cpp:function:: __int64 removeFromStack(HSquirrelVM* sqvm)
 
+    .. note::
+
+        This function (``server.dll+0x7000```) is not available in the launcher or plugins at the moment.
+
+        You can open a PR if you need it now.
+
     :param HSquirrelVM* sqvm: the target vm
 
-    pops the topmost item of the stack.
+    pops the top item of the stack.


### PR DESCRIPTION
- adds disclaimers for functions that are just sq API wrappers and / or not exposed to plugins
- fix examples & typos
- add __sq_call because it offers more control than the ns wrappers
- add defconst
- fix rst labels