### PR TITLE
Update GitHub link for rrplug

### DIFF
--- a/docs/source/squirrel/cpp_api/index.rst
+++ b/docs/source/squirrel/cpp_api/index.rst
@@ -5,7 +5,7 @@ The Squirrel VMs can be manipulated and controlled by Northstar and Plugins.
 
 All functions and macros documented are defined and used in the Northstar Client. For plugins it's recommended to use F1F7Y's `template
 <https://github.com/F1F7Y/R2PluginTemplate>`_ that mirrors the definitions to an extend or `rrplug
-<https://github.com/catornot/rrplug>`_ if you prefer Rust.
+<https://github.com/R2NorthstarTools/rrplug>`_ if you prefer Rust.
 Note that this documentation only covers the C++ API available in the Launcher.
 
 For more information you can read the official library `documentation


### PR DESCRIPTION
`rrplug` has been transferred to Tools org as can be seen when navigating to https://github.com/catornot/rrplug