### PR TITLE
Fix title issue & link issue in damageSourceId section

### DIFF
--- a/docs/source/reference/respawn/damageinfo.rst
+++ b/docs/source/reference/respawn/damageinfo.rst
@@ -111,12 +111,12 @@ Global
 .. cpp:function:: bool IsSuicide( entity attacker, entity victim, int damageSourceId )
 
 damageSourceId
-==============
+--------------
 
 ``damageSourceId`` is an ``int`` that references an ``enum`` and can be used to identify what source damage came from. 
 
 ``damageSourceId`` is mostly found as an argument in some kill and damage related functions. Respawn has created a function that will attempt to localise the damageSourceId inputed.
-To add your own custom ``damageSourceID`` , see: :doc:`customdamagesources`
+To add your own custom ``damageSourceID`` , see: :doc:`../northstar/customdamagesources`
 
 Other useful functions can be found in the ``damageinfo`` section of this page and in :doc:`entities`
 


### PR DESCRIPTION
Should fix the issue of having two titles lead to the same page
Should also fix the issue of the CustomDamagaSources link not working
Also should not have branch conflicts this time