### PR TITLE
Add Tacent View to Modding Tools.

### DIFF
--- a/docs/source/guides/tools/tools.rst
+++ b/docs/source/guides/tools/tools.rst
@@ -70,6 +70,7 @@ Graphics / animation / color editors
   <https://support.apple.com/downloads/quicktime>`_)
 - `TexFactory easy DDS conversion <https://otherbenji.gitlab.io/TexFactory/>`_
 - `Substance Painter to TF2 <https://github.com/EM4Volts/tf-2_substance_maker>`_
+- `Tacent View - image and texture viewer for DDS, among others <https://github.com/bluescan/tacentview>`_
 Archives
 ~~~~~~~~
 


### PR DESCRIPTION
Tacent View is probably the best image and texture viewer for DDS, among others, the developer also quickly added support for some DDS files from Titanfall 2 that couldn't be opened.
https://github.com/bluescan/tacentview/issues/99#issuecomment-1588691246
It uses Dear ImGui, OpenGL and Tacent. Supports Linux and Windows.