### PR TITLE
[Modding Tools] Update Titanfall VPK Tool link

### DIFF
--- a/docs/source/guides/tools/tools.rst
+++ b/docs/source/guides/tools/tools.rst
@@ -7,7 +7,7 @@ Source engine
 Titanfall
 ~~~~~~~~~
 
-- `Titanfall VPK Tool <http://cra0kalo.com/public/Titanfall_VPKTool3.4_Portable.zip>`_
+- `Titanfall VPK Tool <https://cra0.net/public/bin-published/Titanfall_VPKTool3.4_Portable.zip>`_
 - `Harmony VPK Tool <https://github.com/harmonytf/HarmonyVPKTool/>`_
 - `Legion <https://wiki.modme.co/wiki/apps/Legion.html>`_
 


### PR DESCRIPTION
From the [official website](https://cra0.net).
There's no article for 3.4, only a download link, unlike 3.3.