### PR TITLE
MDL Docs, fixed typo, added short video on similar process

### DIFF
--- a/docs/source/guides/tools/MDLModding.rst
+++ b/docs/source/guides/tools/MDLModding.rst
@@ -15,7 +15,6 @@ Editing an existing Model
 While creating an entire Model from scratch is possible it would be an extremely long and tedious task. Instead its recommended to use an existing Model as your base.
 
 
-
 Prequisites
 -----------
 •	`Blender <https://www.blender.org/download/>`__ (min. 2.92)

--- a/docs/source/guides/tools/MDLModding.rst
+++ b/docs/source/guides/tools/MDLModding.rst
@@ -96,7 +96,7 @@ We will use it to combine the MDL file with the other output files from Crowbar.
 Harmony VPK
 -----------
 
-Harmony VPK is a tool written by the Harmony Team. Its an Electron based GUI for VPKTool. It is used to extract files from VPK files.
+Harmony VPK is a tool written by the Harmony Team. It's an electron-based GUI for VPKTool, and is used to extract files from VPK files.
 
 We will use it to extract the model from the game files.
 

--- a/docs/source/guides/tools/MDLModding.rst
+++ b/docs/source/guides/tools/MDLModding.rst
@@ -15,6 +15,7 @@ Editing an existing Model
 While creating an entire Model from scratch is possible it would be an extremely long and tedious task. Instead its recommended to use an existing Model as your base.
 
 
+
 Prequisites
 -----------
 •	`Blender <https://www.blender.org/download/>`__ (min. 2.92)
@@ -58,6 +59,14 @@ The workflow for editing a model is as follows:
 •	Converting the MDL file with other output files using `MDLSHIT <#mdlshit>`__
 
 
+Short Video Guide
+-----------------
+
+This is a short video guide on MDL Editing, there are some discrepancies between the video and this guide but the general workflow is the same.
+Its relatively quick but shows the process quite well.
+
+.. youtube:: mZg5AlWvXZs
+
 Blender
 -------
 
@@ -87,7 +96,7 @@ We will use it to combine the MDL file with the other output files from Crowbar.
 Harmony VPK
 -----------
 
-Harmony VPK is a tool written by headassbtw. It is used to extract the model from the game files.
+Harmony VPK is a tool written by the Harmony Team. Its an Electron based GUI for VPKTool. It is used to extract files from VPK files.
 
 We will use it to extract the model from the game files.
 


### PR DESCRIPTION
Fixed a typo in the short discription of Harmony 

added the short video headassbtw made showcasing a similar process.