### PR TITLE
Fix typo in debug draw section

### DIFF
--- a/docs/source/reference/respawn/debugdraw.rst
+++ b/docs/source/reference/respawn/debugdraw.rst
@@ -1,7 +1,7 @@
 Debug drawing
 =============
 
-In Titanfall it is possible to draw shapes in 3D, from the SERVER and CLIENT VM, using the debug draw functions, however in order for them to actually render you will need to set ``enable_debug_overlay 1`` in your launch config or console.
+In Titanfall it is possible to draw shapes in 3D, from the SERVER and CLIENT VM, using the debug draw functions, however in order for them to actually render you will need to set ``enable_debug_overlays 1`` in your launch config or console.
 
 These debug drawing functions are available:
 


### PR DESCRIPTION
The convar should be `enable_debug_overlays`.

<img width="102" alt="屏幕截图 2023-06-22 161735" src="https://github.com/R2Northstar/ModdingDocs/assets/122596880/50665ff4-436d-41b5-b829-84a6e67bd476">
