### PR TITLE
Fix functionref docs being wrong 

### DIFF
--- a/docs/source/squirrel/functions.rst
+++ b/docs/source/squirrel/functions.rst
@@ -60,7 +60,7 @@ Optional parameters must be declared after all required parameters.
 Passing Functions as parameters
 -------------------------------
 
-If you want to pass a function as a parameter to another function, for example as a callback set their type as ``functionref( [parameters] )``.
+If you want to pass a function as a parameter to another function, for example as a callback set their type as ``[return type] functionref( [parameters] )``.
 
 .. code-block::
 
@@ -69,12 +69,15 @@ If you want to pass a function as a parameter to another function, for example a
     printt( req + opt )
   }
 
-  void function CallLiteral( functionref( int, int ) literal )
+  void function CallLiteral( void functionref( int, int ) literal )
   {
     literal( RandomInt( 5 ) )
   }
 
   CallLiteral( FnLiteral )
+
+
+You are able to leave out the return type of the functionref if your file is ``untyped``, however this is discouraged to keep compatabliliy.
 
 Calling Functions
 -----------------

--- a/docs/source/squirrel/functions.rst
+++ b/docs/source/squirrel/functions.rst
@@ -77,7 +77,9 @@ If you want to pass a function as a parameter to another function, for example a
   CallLiteral( FnLiteral )
 
 
-You are able to leave out the return type of the functionref if your file is ``untyped``, however this is discouraged to keep compatabliliy.
+..note ::
+
+  In ``untyped`` files you may leave out the return type of the function reference. Like in function declarations this will default to ``var`` being the return type.
 
 Calling Functions
 -----------------

--- a/docs/source/squirrel/functions.rst
+++ b/docs/source/squirrel/functions.rst
@@ -77,7 +77,7 @@ If you want to pass a function as a parameter to another function, for example a
   CallLiteral( FnLiteral )
 
 
-..note ::
+.. note ::
 
   In ``untyped`` files you may leave out the return type of the function reference. Like in function declarations this will default to ``var`` being the return type.
 


### PR DESCRIPTION
Mention return types being required for functionrefs in typed files.

For reference, error found in discussion https://discord.com/channels/920776187884732556/922663696273125387/1129343323799298078