### PR TITLE
Add bool to ModSettings types

### DIFF
--- a/docs/source/reference/northstar/modsettings.rst
+++ b/docs/source/reference/northstar/modsettings.rst
@@ -57,6 +57,7 @@ API
   **Types:**
   
   * ``int``
+  * ``bool``
   * ``float``
   * ``float2``
   * ``float3`` / ``vector``


### PR DESCRIPTION
Happened to notice it was missing before
also as of now "int" is not a supported type but I theres already a fix PR in NorthstarMods