### PR TITLE
Add warn for load priority 

### DIFF
--- a/docs/source/reference/northstar/chathooks.rst
+++ b/docs/source/reference/northstar/chathooks.rst
@@ -8,7 +8,6 @@ For an example of chathooks in use, check out EmmaM's `OwOfier mod <https://gith
 .. warning::
 	
 	Your mod needs to be load priority 1 or above to use the structs and callbacks in your script.
-	
 
 
 Client chat API

--- a/docs/source/reference/northstar/chathooks.rst
+++ b/docs/source/reference/northstar/chathooks.rst
@@ -4,6 +4,13 @@ Chathooks
 This document provides usage of the Chathook API added in Northstar ``v1.6.0``.
 For an example of chathooks in use, check out EmmaM's `OwOfier mod <https://github.com/emma-miler/OwOfier/>`_.
 
+
+.. warning::
+	
+	Your mod needs to be load priority 1 or above to use the structs and callbacks in your script.
+	
+
+
 Client chat API
 ---------------
 

--- a/docs/source/reference/northstar/httprequests.rst
+++ b/docs/source/reference/northstar/httprequests.rst
@@ -170,6 +170,11 @@ The HTTP system uses a few enums and structs for requests and their callbacks.
 Functions
 ^^^^^^^^^
 
+.. warning::
+	
+	Your mod needs to be load priority 1 or above to use ``HttpRequest`` and ``HttpRequestResponse`` in your script.
+	
+
 .. _httpapi_funcs_nshttprequest:
 
 .. cpp:function:: bool NSHttpRequest( HttpRequest requestParameters, void functionref( HttpRequestResponse ) onSuccess = null, void functionref( HttpRequestFailure ) onFailure = null )


### PR DESCRIPTION
you cant use HTTP and chathooks when your load prio is 0, that can cause issues. This adds a warn for this