### PR TITLE
Add mention of `sv_cheats` to debugdraw docs

### DIFF
--- a/docs/source/reference/respawn/native_server/debugdraw.rst
+++ b/docs/source/reference/respawn/native_server/debugdraw.rst
@@ -7,7 +7,7 @@ Debug Drawing
 
   The rest are defined in scripts using these.
 
-In Titanfall it is possible to draw shapes in 3D, from the SERVER and CLIENT VM, using the debug draw functions, however in order for them to actually render you will need to set ``enable_debug_overlays 1`` and ``sv_cheats 1`` in your launch config or console.
+In Titanfall it is possible to draw shapes in 3D, from the SERVER and CLIENT VM, using the debug draw functions, however in order for them to actually render you will need to set ``sv_cheats 1`` and ``enable_debug_overlays 1`` in your launch config or console.
 
 These debug drawing functions are available:
 

--- a/docs/source/reference/respawn/native_server/debugdraw.rst
+++ b/docs/source/reference/respawn/native_server/debugdraw.rst
@@ -7,7 +7,7 @@ Debug Drawing
 
   The rest are defined in scripts using these.
 
-In Titanfall it is possible to draw shapes in 3D, from the SERVER and CLIENT VM, using the debug draw functions, however in order for them to actually render you will need to set ``enable_debug_overlays 1`` in your launch config or console.
+In Titanfall it is possible to draw shapes in 3D, from the SERVER and CLIENT VM, using the debug draw functions, however in order for them to actually render you will need to set ``enable_debug_overlays 1`` and ``sv_cheats 1`` in your launch config or console.
 
 These debug drawing functions are available:
 


### PR DESCRIPTION
adds the missing need for sv_cheats 1 to the debugdraw docs. 