### PR TITLE
Replace Unknown Bool from `FireWeaponBullet_Special()`

### DIFF
--- a/docs/source/reference/respawn/entities.rst
+++ b/docs/source/reference/respawn/entities.rst
@@ -1040,7 +1040,7 @@ Shared
 
 		Add a mod to this weapon
 
-	.. cpp:function:: void FireWeaponBullet_Special(vector origin, vector direction, int numShots, int damageType, bool noAntilag, bool noSpread, bool onlyDamageEntitiesOnce, bool unknownPurpose, bool noTracers, bool activeShot, bool doTraceBrushOnly)
+	.. cpp:function:: void FireWeaponBullet_Special(vector origin, vector direction, int numShots, int damageType, bool noAntilag, bool noSpread, bool onlyDamageEntitiesOnce, bool noImpactFX, bool noTracers, bool activeShot, bool doTraceBrushOnly)
 
 	.. cpp:function:: string GetWeaponSettingString( string setting )
 


### PR DESCRIPTION
Replaces `unknownBool` in FireWeaponBullet_Special() with what it does.